### PR TITLE
Upgrade Cypress to version 9.6.0

### DIFF
--- a/node/cypress.json
+++ b/node/cypress.json
@@ -1,6 +1,6 @@
 {
   "chromeWebSecurity": false,
-  "video": true,
+  "video": false,
   "videoCompression": false,
   "videoUploadOnPasses": false,
   "screenshotOnRunFailure": true,

--- a/node/workspace.js
+++ b/node/workspace.js
@@ -120,7 +120,12 @@ async function doLinkApp(config) {
     qe.msg(`Unlinking ${app} if needed`, true, true)
     await qe.toolbelt(config.base.vtex.bin, `unlink ${app}@${version}.x`)
     const ignoreFile = path.join('..', '.vtexignore')
-    const exclusions = ['cypress', 'cy-runner', 'cypress-shared']
+    const exclusions = [
+      'cypress',
+      'cy-runner',
+      'cypress-shared',
+      'docs/**/*.{gif,png,jpg}',
+    ]
 
     qe.msg(`Adding cy-runner exclusions to ${ignoreFile}`, true, true)
     exclusions.forEach((line) => {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@vtex/prettier-config": "^1.0.0",
     "axios": "^0.26.0",
-    "cypress": "^9.5.4",
+    "cypress": "^9.6.0",
     "cypress-file-upload": "^5.0.8",
     "eslint": "^7.4.0",
     "eslint-config-vtex": "^12.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,10 +629,10 @@ cypress-file-upload@^5.0.8:
   resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
   integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
 
-cypress@^9.5.4:
-  version "9.5.4"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.5.4.tgz#49d9272f62eba12f2314faf29c2a865610e87550"
-  integrity sha512-6AyJAD8phe7IMvOL4oBsI9puRNOWxZjl8z1lgixJMcgJ85JJmyKeP6uqNA0dI1z14lmJ7Qklf2MOgP/xdAqJ/Q==
+cypress@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.6.0.tgz#84473b3362255fa8f5e627a596e58575c9e5320f"
+  integrity sha512-nNwt9eBQmSENamwa8LxvggXksfyzpyYaQ7lNBLgks3XZ6dPE/6BCQFBzeAyAPt/bNXfH3tKPkAyhiAZPYkWoEg==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
1. Upgrade Cypress to 9.6.0
2. Disable video recording for the auth process to save time
3. Exclude images when linking app to save time