### PR TITLE
Change 2s to 4s

### DIFF
--- a/cypress-shared/support/common/refund_apis.js
+++ b/cypress-shared/support/common/refund_apis.js
@@ -30,7 +30,7 @@ export function refund(
     'Workflow API should have order status has invoiced',
     updateRetry(5),
     () => {
-      cy.addDelayBetweenRetries(2000)
+      cy.addDelayBetweenRetries(4000)
       cy.getVtexItems().then((vtex) => {
         cy.getOrderItems().then((order) => {
           cy.getAPI(


### PR DESCRIPTION
In Cybersource, 2s is not enough for Workflow API should have order status has invoiced
So, updated to 4s