### PR TITLE
Drop uninstall and unlink before link app

### DIFF
--- a/node/workspace.js
+++ b/node/workspace.js
@@ -113,12 +113,7 @@ async function doLinkApp(config) {
 
     testApp = JSON.parse(testApp)
     const app = `${testApp.vendor}.${testApp.name}`
-    const [version] = testApp.version.split('.')
 
-    qe.msg(`Uninstalling ${app} if needed`, true, true)
-    await qe.toolbelt(config.base.vtex.bin, `uninstall ${app}`)
-    qe.msg(`Unlinking ${app} if needed`, true, true)
-    await qe.toolbelt(config.base.vtex.bin, `unlink ${app}@${version}.x`)
     const ignoreFile = path.join('..', '.vtexignore')
     const exclusions = [
       'cypress',


### PR DESCRIPTION
1. Drop the unlink and uninstall commands used to run before link the App to be tested.