### PR TITLE
Add Cypress Dashboard URL on report

### DIFF
--- a/node/report.js
+++ b/node/report.js
@@ -33,6 +33,12 @@ module.exports.report = async (control, config) => {
         qe.newLine()
       }
     })
+
+    if (control.runUrl != null) {
+      qe.msg('Cypress Dashboard URL for this run')
+      qe.msg(control.runUrl, true, true)
+    }
+
     if (control.specsFailed.length < 1) {
       qe.success('The test ran successfully, well done!')
     } else {


### PR DESCRIPTION
```
[QE] === Execution report ==========================================================================
     ===============================================================================================

     [✓] Execution time
      -  vtexCli....................... 0 seconds
      -  workspace..................... 51.24 seconds
      -  credentials................... 2.181 seconds
      -  strategy...................... 254.219 seconds
      -  teardown...................... 12.728 seconds
      -  total......................... 320.386 seconds

     [✓] Successful specs
      -  cypress/integration/post_setup.spec.js
      -  cypress/integration/sku*
      -  cypress/integration/2.3-promotionalProduct*
      -  cypress/integration/2.5-discountShipping*
      -  cypress/integration/2.1-singleProduct*
      -  cypress/integration/2.2-multiProduct*
      -  cypress/integration/2.6-externalSeller*
      -  cypress/integration/2.4-discountProduct*
      -  cypress/integration/2.9-settlements*
      -  cypress/integration/2.7-fullRefund*
      -  cypress/integration/2.8-partialRefund*

     [✓] Cypress Dashboard URL for this run
      -  http://localhost:8080/run/5731fa83dacb8ba560859f3bd02cecc9

[QE] === SUCCESS ===================================================================================

     [✓] The test ran successfully, well done!
```