### PR TITLE
Improve loginViaCookies()

### DIFF
--- a/cypress-shared/integration/b2b/2.1.1-create_&_approve_organizationA.spec.js
+++ b/cypress-shared/integration/b2b/2.1.1-create_&_approve_organizationA.spec.js
@@ -1,10 +1,10 @@
-import { testSetup } from '../../support/common/support.js'
+import { loginViaCookies } from '../../support/common/support.js'
 import { createOrganizationTestCase } from '../../support/b2b/organization_request.js'
 import b2b from '../../support/b2b/constants.js'
 import { deleteOrganization } from '../../support/b2b/graphql.js'
 
 describe('Create & Approve OrganizationA', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const { organizationName, costCenter1, users } = b2b.OrganizationA
 

--- a/cypress-shared/integration/b2b/2.1.2-create_&_decline_organizationB.spec.js
+++ b/cypress-shared/integration/b2b/2.1.2-create_&_decline_organizationB.spec.js
@@ -1,10 +1,10 @@
-import { testSetup } from '../../support/common/support.js'
+import { loginViaCookies } from '../../support/common/support.js'
 import { createOrganizationTestCase } from '../../support/b2b/organization_request.js'
 import b2b from '../../support/b2b/constants.js'
 import { deleteOrganization } from '../../support/b2b/graphql.js'
 
 describe('Create & Decline OrganizationB', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const { organizationName, costCenter1, users } = b2b.OrganizationB
 

--- a/cypress-shared/integration/b2b/2.1.3-organization_negative_testcases.spec.js
+++ b/cypress-shared/integration/b2b/2.1.3-organization_negative_testcases.spec.js
@@ -1,4 +1,4 @@
-import { testSetup } from '../../support/common/support.js'
+import { loginViaCookies } from '../../support/common/support.js'
 import {
   createOrganizationWithInvalidEmail,
   createOrganizationWithoutName,
@@ -9,7 +9,7 @@ import { loginToStoreFront } from '../../support/b2b/login.js'
 import { ROLE_DROP_DOWN } from '../../support/b2b/utils.js'
 
 describe('Organization Negative TestCases', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
   const email = b2b.OrganizationA.users.OrganizationAdmin1
 
   const { users, gmailCreds } = b2b.OrganizationA

--- a/cypress-shared/integration/b2b/2.1.4-multi_organizations_requests.spec.js
+++ b/cypress-shared/integration/b2b/2.1.4-multi_organizations_requests.spec.js
@@ -1,4 +1,4 @@
-import { testSetup } from '../../support/common/support.js'
+import { loginViaCookies } from '../../support/common/support.js'
 import {
   createOrganizationTestCase,
   requestOrganizationAndVerifyPopup,
@@ -7,7 +7,7 @@ import {
 import b2b, { OrganizationRequestStatus } from '../../support/b2b/constants.js'
 
 describe('Create & Approve OrganizationB', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
   const email = b2b.OrganizationB.users.OrganizationAdmin1
   const name = b2b.OrganizationB.organizationName
   const costCenterName = b2b.OrganizationB.costCenter1.name

--- a/cypress-shared/integration/b2b/2.10-approver_scenarios_orgA_costcenter2.spec.js
+++ b/cypress-shared/integration/b2b/2.10-approver_scenarios_orgA_costcenter2.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import {
   ROLE_DROP_DOWN,
@@ -23,7 +26,7 @@ import {
 } from '../../support/b2b/quotes.js'
 
 describe('Organization A - Cost Center A2 - Approver Scenario', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     organizationName,

--- a/cypress-shared/integration/b2b/2.11-approver_scenarios_orgB.spec.js
+++ b/cypress-shared/integration/b2b/2.11-approver_scenarios_orgB.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import { ROLE_DROP_DOWN } from '../../support/b2b/utils.js'
 import { loginToStoreFront } from '../../support/b2b/login.js'
@@ -19,7 +22,7 @@ import {
 } from '../../support/b2b/quotes.js'
 
 describe('Organization B - Cost Center B1 - Approver Scenario', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     product,

--- a/cypress-shared/integration/b2b/2.12-organization_admin_scenarios-orgA.spec.js
+++ b/cypress-shared/integration/b2b/2.12-organization_admin_scenarios-orgA.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import {
   ROLE_DROP_DOWN,
@@ -33,7 +36,7 @@ import {
 } from '../../support/b2b/quick_order.js'
 
 describe('Organization A - Cost Center A1 - Organization Admin2 Scenario', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     organizationName,

--- a/cypress-shared/integration/b2b/2.13-sales_manager_scenarios.spec.js
+++ b/cypress-shared/integration/b2b/2.13-sales_manager_scenarios.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import {
   ROLE_ID_EMAIL_MAPPING as roleObject,
@@ -44,7 +47,7 @@ function QuotesAccess(
 }
 
 describe('Organization A - Cost Center A1 - Sales Manager Scenario', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     nonAvailableProduct,

--- a/cypress-shared/integration/b2b/2.14-sales_rep_scenarios.spec.js
+++ b/cypress-shared/integration/b2b/2.14-sales_rep_scenarios.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import {
   ROLE_DROP_DOWN,
@@ -45,7 +48,7 @@ function QuotesAccess(
 }
 
 describe('Organization A - Cost Center A1 - Sales Rep Scenario', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     nonAvailableProduct,

--- a/cypress-shared/integration/b2b/2.2-add_buyer_approver_organizationA.spec.js
+++ b/cypress-shared/integration/b2b/2.2-add_buyer_approver_organizationA.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import {
   addPaymentTermsCollectionPriceTablesTestCase,
@@ -25,7 +28,7 @@ import {
 } from '../../support/b2b/quotes.js'
 
 describe('OrganizationA - Create a Buyer and Approver, associate Cost Center and assign payment terms', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     organizationName,

--- a/cypress-shared/integration/b2b/2.3-add_buyer_approver_organizationB.spec.js
+++ b/cypress-shared/integration/b2b/2.3-add_buyer_approver_organizationB.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import {
   addPaymentTermsCollectionPriceTablesTestCase,
@@ -13,7 +16,7 @@ import {
 import { createQuote } from '../../support/b2b/quotes.js'
 
 describe('OrganizationB - Create a Buyer and Approver associate Cost Center and assign payment terms', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const { organizationName, costCenter1, users, product, quotes, gmailCreds } =
     b2b.OrganizationB

--- a/cypress-shared/integration/b2b/2.4-add-remaining-users.spec.js
+++ b/cypress-shared/integration/b2b/2.4-add-remaining-users.spec.js
@@ -1,12 +1,12 @@
 /* eslint-disable jest/valid-expect */
-import { testSetup, updateRetry } from '../../support/common/support.js'
+import { loginViaCookies, updateRetry } from '../../support/common/support.js'
 import { ROLE_ID_EMAIL_MAPPING, OTHER_ROLES } from '../../support/b2b/utils.js'
 import { addUserViaGraphql } from '../../support/b2b/add_users.js'
 import { syncCheckoutUICustom } from '../../support/common/testcase.js'
 import b2b from '../../support/b2b/constants.js'
 
 describe('Sync Checkout UI Custom & Add Sales Users via Graphql', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
   const { gmailCreds } = b2b.OrganizationA
 
   syncCheckoutUICustom()

--- a/cypress-shared/integration/b2b/2.5-buyer_scenarios_orgA_costA1.spec.js
+++ b/cypress-shared/integration/b2b/2.5-buyer_scenarios_orgA_costA1.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import {
   ROLE_DROP_DOWN_EMAIL_MAPPING as role,
@@ -26,7 +29,7 @@ import {
 } from '../../support/b2b/quick_order.js'
 
 describe('Organization A - Cost Center A1 - Buyer Scenarios', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     organizationName,

--- a/cypress-shared/integration/b2b/2.6-buyer_scenarios_orgA_costA2.spec.js
+++ b/cypress-shared/integration/b2b/2.6-buyer_scenarios_orgA_costA2.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import { ROLE_DROP_DOWN, STATUSES } from '../../support/b2b/utils.js'
 import { loginToStoreFront } from '../../support/b2b/login.js'
@@ -17,7 +20,7 @@ import {
 } from '../../support/b2b/quick_order.js'
 
 describe('Organization A - Cost Center A2 - Buyer Scenarios', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
   const {
     organizationName,
     nonAvailableProduct,

--- a/cypress-shared/integration/b2b/2.7-buyer_scenarios_orgB_costB1.spec.js
+++ b/cypress-shared/integration/b2b/2.7-buyer_scenarios_orgB_costB1.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import { ROLE_DROP_DOWN } from '../../support/b2b/utils.js'
 import { loginToStoreFront } from '../../support/b2b/login.js'
@@ -13,7 +16,7 @@ import {
 } from '../../support/b2b/quotes.js'
 
 describe('Organization B - Cost Center B1 - Buyer Scenario', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     organizationName,

--- a/cypress-shared/integration/b2b/2.8-sales_admin_scenarios.spec.js
+++ b/cypress-shared/integration/b2b/2.8-sales_admin_scenarios.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import {
   ROLE_ID_EMAIL_MAPPING as roleObject,
@@ -44,7 +47,7 @@ function QuotesAccess(
 }
 
 describe('Organization A - Cost Center A1 - Sales Admin Scenario', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     product,

--- a/cypress-shared/integration/b2b/2.9-approver_scenarios_orgA.spec.js
+++ b/cypress-shared/integration/b2b/2.9-approver_scenarios_orgA.spec.js
@@ -1,4 +1,7 @@
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import b2b from '../../support/b2b/constants.js'
 import {
   ROLE_DROP_DOWN,
@@ -30,7 +33,7 @@ import {
 } from '../../support/b2b/checkout.js'
 
 describe('Organization A - Cost Center A1 - Approver Scenario', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   const {
     organizationName,

--- a/cypress-shared/integration/b2b/wipe.spec.js
+++ b/cypress-shared/integration/b2b/wipe.spec.js
@@ -7,7 +7,7 @@ import {
   VTEX_AUTH_HEADER,
 } from '../../support/common/constants.js'
 import {
-  testSetup,
+  loginViaCookies,
   updateRetry,
   preserveCookie,
 } from '../../support/common/support.js'
@@ -133,7 +133,7 @@ describe('Wipe datas', () => {
   const { organizationName: organizationB, costCenter1: costCenterB1 } =
     b2b.OrganizationB
 
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   deleteUsers()
   deleteCostCenter(organizationA, costCenter1)

--- a/cypress-shared/integration/location-availability/wipe.spec.js
+++ b/cypress-shared/integration/location-availability/wipe.spec.js
@@ -4,11 +4,14 @@ import {
   updateShippingPolicy,
 } from '../../support/location-availability/shipping-policy.graphql'
 import data from '../../support/location-availability/shipping-policy.json'
-import { testSetup, preserveCookie } from '../../support/common/support.js'
+import {
+  loginViaCookies,
+  preserveCookie,
+} from '../../support/common/support.js'
 import { deleteAllPickupPoints } from '../../support/location-availability/support'
 
 describe('Wipe the pickup points', () => {
-  testSetup(false)
+  loginViaCookies({ storeFrontCookie: false })
 
   deleteAllPickupPoints()
 

--- a/cypress-shared/support/common/support.js
+++ b/cypress-shared/support/common/support.js
@@ -420,7 +420,8 @@ export function stopTestCaseOnFailure() {
   afterEach()
      a) Stop Execution if testcase gets failed in all retries
 */
-// TODO: Update this functionName to be called as loginViaCookies()
+// TODO: Once we replace testSetup() to loginViaCookies() in all projects
+// Then, Move logic() code to loginViaCookies() and delete testSetup(),logic()
 
 function logic(storeFrontCookie, stop) {
   before(() => {
@@ -447,7 +448,7 @@ export function testSetup(storeFrontCookie = true, stop = true) {
   logic(storeFrontCookie, stop)
 }
 
-export function loginViaCookies(storeFrontCookie = true, stop = true) {
+export function loginViaCookies({ storeFrontCookie = true, stop = true } = {}) {
   logic(storeFrontCookie, stop)
 }
 
@@ -458,14 +459,16 @@ export function loginViaCookies(storeFrontCookie = true, stop = true) {
      a) Stop Execution if testcase gets failed in all retries
 */
 
-export function loginViaAPI(stop = true) {
+export function loginViaAPI({ storeFrontCookie = true, stop = true } = {}) {
   before(() => {
     // LoginAsAdmin
     loginAsAdmin()
-    // LoginAsUser and visit home page
-    cy.getVtexItems().then((vtex) => {
-      loginAsUser(vtex.robotMail, vtex.robotPassword)
-    })
+    if (storeFrontCookie) {
+      // LoginAsUser and visit home page
+      cy.getVtexItems().then((vtex) => {
+        loginAsUser(vtex.robotMail, vtex.robotPassword)
+      })
+    }
   })
   if (stop) stopTestCaseOnFailure()
 }


### PR DESCRIPTION
After this PR, gets merged

For future code,
a) testSetup() must be replaced with loginViaCookies()
b) testSetup(false) must be replaced with loginViaCookies({ storeFrontCookie: false })

Because testSetup function name doesn't provide **good context to the user**
So, planning to use loginViaCookies and **passing false confuses the user**


Now, they should pass the propertyName with boolean
**If they give wrong propertyName then it will not work**


We still have testSetup() in code -> It is because still some repos uses testSetup I don't want to break them
Once we replace testSetup() to loginViaCookies() in all projects
Then we will drop testSetup()
