### PR TITLE
ENGINEERS-774 - Use syncCheckoutUICustomAPI instead of syncCheckoutUICustom + payment flow selectors updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [Unreleased]
 
 ### Changed
+- Selectors in affirm payment flow got changed. So, we need to update the selectors in cypress
+- Use syncCheckoutUICustomAPI instead of syncCheckoutUICustom 
+
+### Changed
 - Reorder sales user / organization admin cypress tests
 
 ### Changed

--- a/cypress-shared/integration/affirm/post_setup.spec.js
+++ b/cypress-shared/integration/affirm/post_setup.spec.js
@@ -2,7 +2,7 @@ import { loginViaCookies } from '../../support/common/support.js'
 import {
   startPaymentE2ETests,
   setWorkspaceAndGatewayAffiliations,
-  syncCheckoutUICustom,
+  syncCheckoutUICustomAPI,
 } from '../../support/common/testcase.js'
 
 describe('Setting up affirm in dynamic environment', () => {
@@ -10,5 +10,5 @@ describe('Setting up affirm in dynamic environment', () => {
 
   startPaymentE2ETests()
   setWorkspaceAndGatewayAffiliations()
-  syncCheckoutUICustom()
+  syncCheckoutUICustomAPI()
 })

--- a/cypress-shared/support/affirm/testcase.js
+++ b/cypress-shared/support/affirm/testcase.js
@@ -73,12 +73,10 @@ export function initiatePayment({
 
         cy.getIframeBody('#checkout-application')
           .find(selectors.AffirmIndicatorOption)
-          .first()
           .click()
 
         cy.getIframeBody('#checkout-application')
-          .find(selectors.AffirmIndicatorOption)
-          .last()
+          .find(selectors.AffirmDisClosureCheckbox)
           .click()
 
         cy.getIframeBody('#checkout-application')

--- a/cypress-shared/support/common/selectors.js
+++ b/cypress-shared/support/common/selectors.js
@@ -436,4 +436,5 @@ export default {
   AffirmPhonePin: 'input[data-testid="phone-pin-field"]',
   AffirmInstallmentOption: 'span[data-test="installment-length"]',
   AffirmIndicatorOption: 'div[data-testid="indicator"]', // Auto payment & Privacy policy option selector
+  AffirmDisClosureCheckbox: 'div[data-testid="disclosure-checkbox-indicator"]',
 }


### PR DESCRIPTION
- Selectors in affirm payment flow got changed. So, we need to update the selectors in cypress
- Use syncCheckoutUICustomAPI instead of syncCheckoutUICustom 