### PR TITLE
docs: fix error in .VTEX_QE.json exemple

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ Secrets to store credentials. You can create a file named `.{base.secrets.name}.
     "vtex": {
       "apiKey": "",
       "apiToken": "",
-      "cookieName": "",
+      "authCookieName": "",
       "robotMail": "",
       "robotPassword": ""
     },


### PR DESCRIPTION
the correnct propretier name is "authCookieName" don't "cookieName"  https://prnt.sc/glxsCRhKjUSY