### PR TITLE
Change expected status on reserving resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- [ENGINEERS-1150] Fix resource reservation expected status
+
 ## [2.3.1] - 2023-02-17
 
 ### Fixed

--- a/node/lock.js
+++ b/node/lock.js
@@ -129,8 +129,11 @@ async function setOrderFormConfig(config, secrets) {
   const axiosConfig = { url, method: 'post', headers, data: config.data }
   const result = await http.request(axiosConfig)
 
-  if (result?.status !== 204) {
-    system.crash('Failed to set up orderForm configuration', result?.data)
+  if (/10?|30?|40?|50?/.test(result?.status)) {
+    system.crash(
+      'Failed to set up orderForm configuration',
+      `HTTP status: result?.status`
+    )
   }
 }
 


### PR DESCRIPTION
When reserving resources the status to succeed used to be 204. Now it is 200, so adding a broad check to accept all 20x status.