### PR TITLE
Fix regex to check orderForm configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- [ENGINEERS-1162] Fix regex to check orderForm configuration status
+
 ## [2.3.3] - 2023-02-17
 
 ### Fixed

--- a/node/lock.js
+++ b/node/lock.js
@@ -129,7 +129,7 @@ async function setOrderFormConfig(config, secrets) {
   const axiosConfig = { url, method: 'post', headers, data: config.data }
   const result = await http.request(axiosConfig)
 
-  if (/10?|30?|40?|50?/.test(result?.status)) {
+  if (!/20./.test(result?.status)) {
     system.crash(
       'Failed to set up orderForm configuration',
       `HTTP status: ${result?.status}`


### PR DESCRIPTION
Fix an error on regex made earlier to check the orderForm configuration status.