### PR TITLE
[ENGINEERS-1184] - Import axios with ES6 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- [ENGINEERS-1184] Fixed TypeError: axios is not a function
+
 ## [2.4.0] - 2023-03-02
 
 ### Fixed

--- a/cypress-shared/support/common/gmail.js
+++ b/cypress-shared/support/common/gmail.js
@@ -1,7 +1,8 @@
 /* eslint-disable func-names */
 /* eslint-disable no-console */
 
-const axios = require('axios')
+import axios from 'axios'
+
 const qs = require('qs')
 
 async function getHeaders(accessToken) {


### PR DESCRIPTION
[ENGINEERS-1184] Fixed TypeError: axios is not a function
#changingTooling

[ENGINEERS-1184]: https://vtex-dev.atlassian.net/browse/ENGINEERS-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ