### PR TITLE
Update events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- URLs for Events to avoid timeouts
+
 ## [2.5.0] - 2023-08-31
 
 ### Removed

--- a/cypress-shared/support/b2b/login.js
+++ b/cypress-shared/support/b2b/login.js
@@ -5,7 +5,7 @@ export function visitHomePage() {
   cy.getVtexItems().then((vtex) => {
     cy.url().then((url) => {
       if (url.includes('blank') || url !== vtex.baseUrl) {
-        cy.intercept('POST', 'https://rc.vtex.com.br/api/events').as('EVENTS')
+        cy.intercept('POST', 'https://sp.vtex.com/event-api/v1/*/event').as('EVENTS')
         cy.qe(
           'Visit home page/storefront and wait for EVENTS api to get called'
         )

--- a/cypress-shared/support/b2b/login.js
+++ b/cypress-shared/support/b2b/login.js
@@ -5,7 +5,9 @@ export function visitHomePage() {
   cy.getVtexItems().then((vtex) => {
     cy.url().then((url) => {
       if (url.includes('blank') || url !== vtex.baseUrl) {
-        cy.intercept('POST', 'https://sp.vtex.com/event-api/v1/*/event').as('EVENTS')
+        cy.intercept('POST', 'https://sp.vtex.com/event-api/v1/*/event').as(
+          'EVENTS'
+        )
         cy.qe(
           'Visit home page/storefront and wait for EVENTS api to get called'
         )

--- a/cypress-shared/support/b2b/organization_request.js
+++ b/cypress-shared/support/b2b/organization_request.js
@@ -42,7 +42,7 @@ function verifyOrganizationData(
         retryOnStatusCodeFailure: true,
         retryOnNetworkFailure: true,
       })
-      cy.intercept('POST', 'https://rc.vtex.com.br/api/events').as('EVENTS')
+      cy.intercept('POST', 'https://sp.vtex.com/event-api/v1/*/event').as('EVENTS')
       cy.wait('@EVENTS')
     }
 

--- a/cypress-shared/support/b2b/organization_request.js
+++ b/cypress-shared/support/b2b/organization_request.js
@@ -42,7 +42,9 @@ function verifyOrganizationData(
         retryOnStatusCodeFailure: true,
         retryOnNetworkFailure: true,
       })
-      cy.intercept('POST', 'https://sp.vtex.com/event-api/v1/*/event').as('EVENTS')
+      cy.intercept('POST', 'https://sp.vtex.com/event-api/v1/*/event').as(
+        'EVENTS'
+      )
       cy.wait('@EVENTS')
     }
 

--- a/cypress-shared/support/commands.js
+++ b/cypress-shared/support/commands.js
@@ -262,7 +262,7 @@ Cypress.Commands.add('orderProduct', () => {
 })
 
 Cypress.Commands.add('openStoreFront', (login = false) => {
-  cy.intercept('**/rc.vtex.com.br/api/events').as('events')
+  cy.intercept('**/event-api/v1/*/event').as('events')
   cy.qe('Visit store front')
   cy.visit('/')
   cy.wait('@events')

--- a/cypress-shared/support/common/support.js
+++ b/cypress-shared/support/common/support.js
@@ -70,7 +70,7 @@ export function addProduct(
   Verfiying the search result is visible and having the text ${searchKey} in lowercase
   Verifying the ProfileLabel should be visible and contain the text Hello
   Verifying the BrandFilter should not be disabled
-  Adding product - ${searchKey} to cart 
+  Adding product - ${searchKey} to cart
   Verify the shipping and taxes in the mini cart
   click on proceed to checkout
   `)
@@ -291,10 +291,10 @@ export function updateShippingInformation({
   cy.qe(
     `Click on proceed to payment button
     Fill the contact information by filling the firstname,lastName and phone number
-    Adding intercept for shipping data 
+    Adding intercept for shipping data
     Select the country and fill the address in the shipping address
     Click on DeliveryAddressText and wait for shippingdata intercept be completed
-    Select pickup in store option in shipping preview container 
+    Select pickup in store option in shipping preview container
     Click on ProceedtoPaymentBtn
     `
   )
@@ -477,7 +477,7 @@ export function searchProduct(searchKey) {
   cy.qe(
     `Adding intercept to wait for the events API to be completed before visting home page`
   )
-  cy.intercept('**/rc.vtex.com.br/api/events').as('events')
+  cy.intercept('**/event-api/v1/*/event').as('events')
   cy.visit('/')
   cy.wait('@events')
   cy.qe("Verify the store front page should contain 'Hello'")

--- a/cypress-shared/support/shopper-location/common.js
+++ b/cypress-shared/support/shopper-location/common.js
@@ -15,7 +15,7 @@ export function verifyShopperLocation() {
 }
 
 export function addLocation(data) {
-  cy.intercept('**/rc.vtex.com.br/api/events').as('events')
+  cy.intercept('**/event-api/v1/*/event').as('events')
   cy.qe('Visit Store frontend')
   cy.visit('/', mockLocation(data.lat, data.long))
   cy.wait('@events')
@@ -57,7 +57,7 @@ export function addLocation(data) {
 }
 
 export function verifyLocation(lat, long) {
-  cy.intercept('**/rc.vtex.com.br/api/events').as('events')
+  cy.intercept('**/event-api/v1/*/event').as('events')
   cy.qe(`${lat ? 'Enable' : 'Disable'} location permission in the browser`)
   cy.visit('/', mockLocation(lat, long))
   cy.qe('Visit store front')
@@ -80,7 +80,7 @@ export function addAddress(prefix, { address, lat, long }) {
     `${prefix} - Go to store front and add shipping address`,
     updateRetry(1),
     () => {
-      cy.intercept('**/rc.vtex.com.br/api/events').as('events')
+      cy.intercept('**/event-api/v1/*/event').as('events')
       cy.qe(
         'Visiting store front and using mocklocation function to setting the location'
       )


### PR DESCRIPTION
Remove '**/rc.vtex.com.br/api/events' and add '**/event-api/v1/*/event' (analytics for IS) to avoid timeouts at the cypress test.

The rc.vtex.com.br was deprecated for the activeFlow http://af.vtex.com/

